### PR TITLE
feat: add mobile screenshot carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
     html { scroll-behavior: smooth; }
     body { font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
     .neon { text-shadow: 0 0 8px rgba(255,60,166,.35), 0 0 18px rgba(46,201,255,.25); }
+    /* Прячем скроллбар у карусели */
+    .no-scrollbar::-webkit-scrollbar { display: none; }
+    .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
   </style>
 </head>
 <body class="bg-[#0b0f1a] text-gray-200 antialiased selection:bg-pink-300/20 selection:text-white">
@@ -61,21 +64,21 @@
   <!-- Как это работает -->
   <section id="app" class="py-16 max-w-6xl mx-auto px-4">
     <h2 class="text-2xl md:text-3xl font-bold text-center mb-12">Как это работает?</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
-      <figure class="group rounded-xl   shadow-sm hover:shadow-md ">
-        <img src="./assets/img/tasks.webp" alt="Скриншот 1" class="rounded-lg  object-cover group-hover:scale-[1.02] transition">
+    <div class="flex gap-6 overflow-x-auto snap-x snap-mandatory no-scrollbar sm:grid sm:grid-cols-2 md:grid-cols-4 sm:overflow-visible">
+      <figure class="flex-shrink-0 w-3/4 sm:w-auto snap-center group rounded-xl shadow-sm hover:shadow-md">
+        <img src="./assets/img/tasks.webp" alt="Скриншот 1" class="rounded-lg w-full object-cover group-hover:scale-[1.02] transition">
         <figcaption class="mt-3 text-center text-sm text-gray-300">Выполняй квесты</figcaption>
       </figure>
-      <figure class="group rounded-xl   shadow-sm hover:shadow-md ">
-        <img src="./assets/img/house.webp" alt="Скриншот 2" class="rounded-lg  object-cover group-hover:scale-[1.02] transition">
+      <figure class="flex-shrink-0 w-3/4 sm:w-auto snap-center group rounded-xl shadow-sm hover:shadow-md">
+        <img src="./assets/img/house.webp" alt="Скриншот 2" class="rounded-lg w-full object-cover group-hover:scale-[1.02] transition">
         <figcaption class="mt-3 text-center text-sm text-gray-300">Копи энергию</figcaption>
       </figure>
-      <figure class="group rounded-xl   shadow-sm hover:shadow-md ">
-        <img src="./assets/img/shop.webp" alt="Скриншот 3" class="rounded-lg  object-cover group-hover:scale-[1.02] transition">
+      <figure class="flex-shrink-0 w-3/4 sm:w-auto snap-center group rounded-xl shadow-sm hover:shadow-md">
+        <img src="./assets/img/shop.webp" alt="Скриншот 3" class="rounded-lg w-full object-cover group-hover:scale-[1.02] transition">
         <figcaption class="mt-3 text-center text-sm text-gray-300">Обменивай на подарки</figcaption>
       </figure>
-      <figure class="group rounded-xl   shadow-sm hover:shadow-md ">
-        <img src="./assets/img/raffles.webp" alt="Скриншот 4" class="rounded-lg  object-cover group-hover:scale-[1.02] transition">
+      <figure class="flex-shrink-0 w-3/4 sm:w-auto snap-center group rounded-xl shadow-sm hover:shadow-md">
+        <img src="./assets/img/raffles.webp" alt="Скриншот 4" class="rounded-lg w-full object-cover group-hover:scale-[1.02] transition">
         <figcaption class="mt-3 text-center text-sm text-gray-300">Участвуй в розыгрышах</figcaption>
       </figure>
     </div>


### PR DESCRIPTION
## Summary
- make screenshot section swipeable on small screens using flex and scroll snapping
- hide scrollbar for cleaner mobile presentation

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a48c14a360832e957986ef558deb17